### PR TITLE
Notify when a new refresh_token has been generated and construct with existing refreshToken

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,7 @@ function getClient(accessToken) {
         })
         .then(client => {
             resolve(client);
-        });
+        }).catch(reject);
     });
 }
 
@@ -51,7 +51,7 @@ function refreshToken(clientSecret, refreshToken) {
                     timestamp: Date.now()
                 });
             } else {
-                reject(error);
+                reject(response);
             }
         });
     });
@@ -92,7 +92,7 @@ function getTokens(clientId, clientSecret, authCode) {
                     timestamp: Date.now()
                 });
             } else {
-                reject(error);
+                reject(response);
             }
         });
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,7 +48,7 @@ function refreshToken(clientSecret, refreshToken) {
                     access_token: json.access_token,
                     refresh_token: json.refresh_token,
                     expires_in: json.expires_in,
-                    timestamp: Date.now()
+                    timestamp: Math.floor(Date.now()/1000)
                 });
             } else {
                 reject(response);
@@ -89,7 +89,7 @@ function getTokens(clientId, clientSecret, authCode) {
                     access_token: json.access_token,
                     refresh_token: json.refresh_token,
                     expires_in: json.expires_in,
-                    timestamp: Date.now()
+                    timestamp: Math.floor(Date.now()/1000)
                 });
             } else {
                 reject(response);

--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ class HomeConnect extends EventEmitter {
     }
 
     async command(tag, operationId, haid, body) {
-        if (Date.now() > (this.tokens.timestamp + this.tokens.expires_in)) {
+        if (Math.floor(Date.now()/1000) > (this.tokens.timestamp + this.tokens.expires_in)) {
             this.tokens = await utils.refreshToken(this.clientSecret, this.tokens.refresh_token);
             this.emit("newRefreshToken", this.tokens.refresh_token);
             this.client = await utils.getClient(this.tokens.access_token);

--- a/main.js
+++ b/main.js
@@ -19,17 +19,7 @@ class HomeConnect extends EventEmitter {
         return new Promise((resolve, reject) => {
 
           if(this.refreshToken){
-            return utils.refreshToken(this.clientSecret, this.refreshToken).then(tokens => {
-                this.tokens = tokens;
-                this.emit("newRefreshToken", tokens.refresh_token);
-                return utils.getClient(this.tokens.access_token);
-            })
-            .then(client => {
-                this.client = client;
-                resolve();
-            });
-          }else{
-            return utils.authorize(this.clientId, this.clientSecret)
+            utils.refreshToken(this.clientSecret, this.refreshToken)
             .then(tokens => {
                 this.tokens = tokens;
                 this.emit("newRefreshToken", tokens.refresh_token);
@@ -38,7 +28,18 @@ class HomeConnect extends EventEmitter {
             .then(client => {
                 this.client = client;
                 resolve();
-            });
+            }).catch(reject);
+          }else{
+            utils.authorize(this.clientId, this.clientSecret)
+            .then(tokens => {
+                this.tokens = tokens;
+                this.emit("newRefreshToken", tokens.refresh_token);
+                return utils.getClient(this.tokens.access_token);
+            })
+            .then(client => {
+                this.client = client;
+                resolve();
+            }).catch(reject);
           }
         });
     }

--- a/main.js
+++ b/main.js
@@ -3,9 +3,10 @@ const utils = require('./lib/utils');
 
 class HomeConnect {
 
-    constructor(clientId, clientSecret) {
+    constructor(clientId, clientSecret, refreshToken) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.refreshToken = refreshToken;
         this.eventSources = {};
     }
 
@@ -15,6 +16,17 @@ class HomeConnect {
             && typeof options.isSimulated === 'boolean') ? options.isSimulated : false;
 
         return new Promise((resolve, reject) => {
+
+          if(this.refreshToken){
+            return utils.refreshToken(this.clientSecret, this.refreshToken).then(tokens => {
+                this.tokens = tokens;
+                return utils.getClient(this.tokens.access_token);
+            })
+            .then(client => {
+                this.client = client;
+                resolve();
+            });
+          }else{
             return utils.authorize(this.clientId, this.clientSecret)
             .then(tokens => {
                 this.tokens = tokens;
@@ -24,6 +36,7 @@ class HomeConnect {
                 this.client = client;
                 resolve();
             });
+          }
         });
     }
 

--- a/main.js
+++ b/main.js
@@ -7,7 +7,8 @@ class HomeConnect extends EventEmitter {
       super()
       this.clientId = clientId;
       this.clientSecret = clientSecret;
-      this.refreshToken = refreshToken;
+      this.tokens = {}
+      this.tokens.refresh_token = refreshToken;
       this.eventSources = {};
     }
 
@@ -18,8 +19,8 @@ class HomeConnect extends EventEmitter {
 
         return new Promise((resolve, reject) => {
 
-          if(this.refreshToken){
-            utils.refreshToken(this.clientSecret, this.refreshToken)
+          if(this.tokens.refresh_token){
+            utils.refreshToken(this.clientSecret, this.tokens.refresh_token)
             .then(tokens => {
                 this.tokens = tokens;
                 this.emit("newRefreshToken", tokens.refresh_token);

--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ class HomeConnect extends EventEmitter {
     async command(tag, operationId, haid, body) {
         if (Date.now() > (this.tokens.timestamp + this.tokens.expires_in)) {
             this.tokens = await utils.refreshToken(this.clientSecret, this.tokens.refresh_token);
-            this.emit("newRefreshToken", tokens.refresh_token);
+            this.emit("newRefreshToken", this.tokens.refresh_token);
             this.client = await utils.getClient(this.tokens.access_token);
         }
         return this.client.apis[tag][operationId]({ haid, body });


### PR DESCRIPTION
We made some minor changes:

- extend EventEmitter to notify when a new refreshToken has been generated
  - this helped us develop a long running microservice using home-connect-js

- add refreshToken to the constructor
  - with initialize HomeConnect with an existing refreshToken

- add/change some error handling for better debugging

Hi, @pckhib hope you find time to review and merge this.